### PR TITLE
cypress test on secure test is now on

### DIFF
--- a/cypress/e2e/claimApplication/secureTest.cy.js
+++ b/cypress/e2e/claimApplication/secureTest.cy.js
@@ -4,14 +4,14 @@ describe("page without new JS", () => {
     cy.visit("https://securest.dol.state.nj.us/tdi_iam/TDIIntroduction.aspx");
   });
 
-  xit("proceeds through an example user flow", () => {
+  it("proceeds through an example user flow", () => {
     // Login page
-    cy.get('#idToken1').type('doltest@mailinator.com');
+    cy.get('#idToken1').type('johnsmith2205@mailinator.com');
     cy.get('#idToken2').type('Test@123');
     cy.get('#loginButton_0').click();
 
     // TDI Introduction
-    cy.get('#ContentPlaceHolder1_chkAgree', { timeout: 300000 }).check();
+    cy.get('#ContentPlaceHolder1_chkAgree', { timeout: 3000000 }).check();
 
     // Profile Info 1
     cy.get('#ContentPlaceHolder1_ClaimantProfileTab_PERSONNEL_rbtnPersYes').click();
@@ -32,8 +32,8 @@ describe("page without new JS", () => {
     
     // Citizenship and Contact Info
     cy.get('#ContentPlaceHolder1_ClaimantProfileTab_tpnlCitizen_rbtnCitizenYes').click();
-    cy.get('#ContentPlaceHolder1_ClaimantProfileTab_tpnlCitizen_TxtEmail').type('doltest@mailinator.com');
-    cy.get('#ContentPlaceHolder1_ClaimantProfileTab_tpnlCitizen_TxtConEmail').type('doltest@mailinator.com');
+    cy.get('#ContentPlaceHolder1_ClaimantProfileTab_tpnlCitizen_TxtEmail').type('johnsmith2205@mailinator.com');
+    cy.get('#ContentPlaceHolder1_ClaimantProfileTab_tpnlCitizen_TxtConEmail').type('johnsmith2205@mailinator.com');
     cy.get('#ContentPlaceHolder1_ClaimantProfileTab_tpnlCitizen_rbnRepNo').click();
     cy.get('#ContentPlaceHolder1_ClaimantProfileTab_tpnlCitizen_btnSave').click();
 
@@ -42,73 +42,52 @@ describe("page without new JS", () => {
     cy.get('#ContentPlaceHolder1_ClaimantProfileTab_tpnlVerification_btncontinueVer').click();
     
     // Disability Information
-    const currentDate = new Date();
-    const tenDaysAgo = new Date(currentDate);
-    tenDaysAgo.setDate(currentDate.getDate() - 10);
-    const formattedTenDaysAgo = (
-      (tenDaysAgo.getMonth() + 1).toString().padStart(2, '0') + '/' +
-      tenDaysAgo.getDate().toString().padStart(2, '0') + '/' +
-      tenDaysAgo.getFullYear()
-    );
-    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_Dis1_txtDisStartDt').type(formattedTenDaysAgo);
-
-    const elevenDaysAgo = new Date(currentDate);
-    elevenDaysAgo.setDate(currentDate.getDate() - 11);
-    const formattedElevenDaysAgo = (
-      (elevenDaysAgo.getMonth() + 1).toString().padStart(2, '0') + '/' +
-      elevenDaysAgo.getDate().toString().padStart(2, '0') + '/' +
-      elevenDaysAgo.getFullYear()
-    );
-    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_Dis1_txtDtLastWorkd').type(formattedElevenDaysAgo);
-    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_Dis1_rbtnRecNo').click();
-
-    const twentyDaysFromNow = new Date(currentDate);
-    twentyDaysFromNow.setDate(currentDate.getDate() + 20);
-    const formattedTwentyDaysFromNow = (
-      (twentyDaysFromNow.getMonth() + 1).toString().padStart(2, '0') + '/' +
-      twentyDaysFromNow.getDate().toString().padStart(2, '0') + '/' +
-      twentyDaysFromNow.getFullYear()
-    );
-    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_Dis1_txtExpectedReturnedDtToWrk').type(formattedTwentyDaysFromNow);
+    // Note: expiration logic here is unclear. these dates may eventually need to be made later.
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_Dis1_txtDisStartDt').type("08/03/2024");
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_Dis1_txtDtLastWorkd').type("08/01/2024");
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_Dis1_rbtnRecYes').click();
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_Dis1_txtDtReturnedToWrk').type("08/05/2024");
     cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_Dis1_btnSubmitConflictCheck').click();
+
+    // Medical Treatment Info
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_txtInjury').type('Injury');
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_txtDocNm').type('Dr. Spaceman');
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_rbnDocAddYes').click();
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_txtDocAdd1').type('30 Livingston Avenue');
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_txtDocCity').type('New Brunswick');
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_txtDocZip1').type('08901');
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_rbtnERNO').click();
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_rbtnHospNo').click();
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_rbtnInjNo').click();
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_btnDoc').click();
+
+    // Other Benefits
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabBenefits_rbTDINo').click();
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabBenefits_rbTDEmpNo').click();
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabBenefits_rbSSNo').click();
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabBenefits_rbUINo').click();
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabBenefits_btnUI').click();
+
+    // Payment Information
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_tbpnlLatePayment_rbtnDisNo').click();
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_tbpnlLatePayment_lpayReason').type('Waited.');
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_tbpnlLatePayment_btnNextVer').click();
+
+    // Disability Verification
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_tabpnlDisabilityVerification_rbtnDisabsYes').click();
+    cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_tabpnlDisabilityVerification_btncontinueVer').click();
+
+    // Employment Information
+    cy.get('#ContentPlaceHolder1_TabEmployment_tbpnlEMP_btnEmpCertify').click();
 
     // TODO: unable to fully test on ST unless we have an account where we can repeatedly apply
 
-    // Medical Treatment Info
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_txtInjury').type('Injury');
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_txtDocNm').type('Dr. Spaceman');
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_rbnDocAddYes').click();
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_txtDocAdd1').type('30 Livingston Avenue');
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_txtDocCity').type('New Brunswick');
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_txtDocZip1').type('08901');
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_rbtnERNO').click();
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_rbtnHospNo').click();
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_rbtnInjNo').click();
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabDoctor_btnDoc').click();
+    // Claimant Certification
+    cy.get('#ContentPlaceHolder1_ClaimantCertTab_TPCertification_rbtnAgNo').should('be.visible');
+    cy.get('#ContentPlaceHolder1_ClaimantCertTab_TPCertification_rbtnAgYes').should('be.visible');
+    cy.get('#ContentPlaceHolder1_ClaimantCertTab_TPCertification_btnConfirm').should('be.visible');
 
-    // // Other Benefits
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabBenefits_rbTDINo').click();
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabBenefits_rbTDEmpNo').click();
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabBenefits_rbSSNo').click();
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabBenefits_rbUINo').click();
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_TabBenefits_btnUI').click();
-
-    // // Payment Information
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_tbpnlLatePayment_rbtnDisNo').click();
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_tbpnlLatePayment_btnNextVer').click();
-
-    // // Disability Verification
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_tabpnlDisabilityVerification_rbtnDisabsYes').click();
-    // cy.get('#ContentPlaceHolder1_ClaimantDisabilityTab_tabpnlDisabilityVerification_btncontinueVer').click();
-
-    // // Employment Information
-    // cy.get('#ContentPlaceHolder1_TabEmployment_tbpnlEMP_btnEmpCertify').click();
-
-    // // Claimant Certification
-    // cy.get('#ContentPlaceHolder1_ClaimantCertTab_TPCertification_rbtnAgYes').click();
-    // cy.get('#ContentPlaceHolder1_ClaimantCertTab_TPCertification_btnConfirm').click();
-
-    // // Claimant Confirmation
+    // Claimant Confirmation
     // cy.get('#ContentPlaceHolder1_ClaimantCertTab_TPConfirmation_btnContinue').click();
   });
 });

--- a/cypress/e2e/claimApplication/secureTest.cy.js
+++ b/cypress/e2e/claimApplication/secureTest.cy.js
@@ -1,6 +1,7 @@
 describe("page without new JS", () => {
   beforeEach(() => {
     cy.intercept('**/tdiOverride.min.js', { body: '', disableCache: true }).as('scriptIntercept');
+    cy.on('uncaught:exception', (_err, _runnable) => { return false; });
     cy.visit("https://securest.dol.state.nj.us/tdi_iam/TDIIntroduction.aspx");
   });
 


### PR DESCRIPTION
This test can be turned off again in the future if it proves to be brittle by changing the `it` back to `xit`. I wouldn't want to leave it sitting off for too long though or it will get out of date-- better to either fix or just delete.

Reasons it might be brittle:

* There is a long timeout when signing in. I think this is because the Secure Test environment turns off resources when dormant, so the first access of the day can take around ~1 minute. After that, it should take 5-10 seconds.

* Claims created and certified are actually saved in the database, and we have no way to clear those out.
  * So we can only go up *to* the certification step and then stop the test.
  * Also, this means the dates input have to be real, and there is an unknown check being run on those dates. The test may fail and the dates would have to change.


All that being said, I think it's still worth trying to run this test regularly to quickly verify that deployments to Dev are going well.